### PR TITLE
documentation drive: mention stringify in the format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ ms.client('channel', function(err, stream) {
     })
   );
 });
+
+//the address has no parameters, there is only one react native channel
+ms.stringify() => "channel"
 ```
+note, there is no scope option. scope is always `device`.
+
 
 **backend.js**
 


### PR DESCRIPTION
I was doing documentation for multiserver which linked here, just needed to add something to show what stringify() output looks like.